### PR TITLE
Improve display card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Futures Tracker</title>
+    <!-- Include Tailwind via CDN for quick styling -->
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -37,8 +37,7 @@ const FuturesModal = () => {
   });
 
   return (
-    <div className="min-h-screen bg-black text-white flex items-center justify-center px-4 py-10">
-      <div className="w-full max-w-[600px] bg-neutral-900 border border-white/10 rounded-2xl shadow-xl p-6">
+    <div className="w-full max-w-[600px] text-white bg-neutral-900 border border-white/10 rounded-2xl shadow-xl p-6">
         {/* Tabs */}
         <div className="flex justify-center mb-4 flex-wrap gap-2">
           {typeOptions.map((type) => (
@@ -89,7 +88,6 @@ const FuturesModal = () => {
           ))}
         </div>
       </div>
-    </div>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: dark;
+  color: #ffffff;
+  background-color: #111111;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -25,9 +25,12 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  align-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #111111;
+  color: #ffffff;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- enable Tailwind via CDN and update document title
- switch global styles to dark mode and center content
- slim down `FuturesModal` markup so only the card is rendered

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68896ac022bc8326b6c36a6c356d12da