### PR TITLE
Add bet form modal on Futures page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ src/
 
 ## 📌 Next Features
 
-- [ ] Add bet form input UI
+- [x] Add bet form input UI via + button modal
 - [ ] LocalStorage or Firebase save
 - [ ] Export to image (for sharing)
 - [ ] Discord bot integration (`/bzero` commands)

--- a/src/components/AddBetModal.jsx
+++ b/src/components/AddBetModal.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+
+const AddBetModal = ({ onClose }) => {
+  const [form, setForm] = useState({
+    league: "",
+    subject: "",
+    info: "",
+    odds: "",
+  });
+  const [message, setMessage] = useState("");
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage("");
+    try {
+      const res = await fetch("/api/bets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("Request failed");
+      setForm({ league: "", subject: "", info: "", odds: "" });
+      setMessage("Bet saved!");
+    } catch {
+      setMessage("Error saving bet.");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-neutral-900 w-full max-w-md p-6 rounded-xl space-y-3 text-white">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-lg font-semibold">Add Bet</h2>
+          <button onClick={onClose} className="text-xl leading-none">✕</button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            className="w-full p-2 bg-neutral-800 rounded"
+            placeholder="League"
+            name="league"
+            value={form.league}
+            onChange={handleChange}
+            required
+          />
+          <input
+            className="w-full p-2 bg-neutral-800 rounded"
+            placeholder="Subject"
+            name="subject"
+            value={form.subject}
+            onChange={handleChange}
+            required
+          />
+          <input
+            className="w-full p-2 bg-neutral-800 rounded"
+            placeholder="Bet info"
+            name="info"
+            value={form.info}
+            onChange={handleChange}
+            required
+          />
+          <input
+            className="w-full p-2 bg-neutral-800 rounded"
+            placeholder="Odds"
+            name="odds"
+            value={form.odds}
+            onChange={handleChange}
+            required
+          />
+          <button type="submit" className="w-full bg-white text-black py-2 rounded">
+            Submit
+          </button>
+          {message && <p className="text-center text-sm">{message}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddBetModal;

--- a/src/pages/FuturesPage.jsx
+++ b/src/pages/FuturesPage.jsx
@@ -1,10 +1,24 @@
 // src/pages/FuturesPage.jsx
 
-import React from "react";
+import React, { useState } from "react";
 import FuturesModal from "../components/FuturesModal";
+import AddBetModal from "../components/AddBetModal";
 
 const FuturesPage = () => {
-  return <FuturesModal />;
+  const [showAdd, setShowAdd] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setShowAdd(true)}
+        className="absolute top-0 right-0 m-4 text-3xl text-white w-8 h-8 flex items-center justify-center rounded-full bg-neutral-800 hover:bg-neutral-700"
+        aria-label="Add Bet"
+      >
+        +
+      </button>
+      <FuturesModal />
+      {showAdd && <AddBetModal onClose={() => setShowAdd(false)} />}
+    </div>
+  );
 };
 
 export default FuturesPage;


### PR DESCRIPTION
## Summary
- implement `AddBetModal` component with form submission
- show `AddBetModal` from `FuturesPage` via new `+` button
- document add bet modal in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68896f85ab0c8326929af7114b9bb810