### PR TITLE
Update bet form fields

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,12 +32,20 @@ app.get('/api/bets', (req, res) => {
 });
 
 app.post('/api/bets', (req, res) => {
-  const { league, subject, info, odds } = req.body;
-  if (!league || !subject || !info || !odds) {
+  const { league, subjectType, subject, bet, line, odds } = req.body;
+  if (!league || !subjectType || !subject || !bet || !odds) {
     return res.status(400).json({ error: 'Missing fields' });
   }
   const bets = loadBets();
-  const newBet = { league, subject, info, odds, date: new Date().toISOString() };
+  const newBet = {
+    league,
+    subjectType,
+    subject,
+    bet,
+    line: line || null,
+    odds,
+    date: new Date().toISOString(),
+  };
   bets.push(newBet);
   saveBets(bets);
   res.status(201).json(newBet);

--- a/src/components/AddBetModal.jsx
+++ b/src/components/AddBetModal.jsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 
 const AddBetModal = ({ onClose }) => {
   const [form, setForm] = useState({
-    league: "",
+    league: "NBA",
+    subjectType: "Team",
     subject: "",
-    info: "",
+    bet: "",
+    line: "",
     odds: "",
   });
   const [message, setMessage] = useState("");
@@ -23,7 +25,14 @@ const AddBetModal = ({ onClose }) => {
         body: JSON.stringify(form),
       });
       if (!res.ok) throw new Error("Request failed");
-      setForm({ league: "", subject: "", info: "", odds: "" });
+      setForm({
+        league: "NBA",
+        subjectType: "Team",
+        subject: "",
+        bet: "",
+        line: "",
+        odds: "",
+      });
       setMessage("Bet saved!");
     } catch {
       setMessage("Error saving bet.");
@@ -38,14 +47,30 @@ const AddBetModal = ({ onClose }) => {
           <button onClick={onClose} className="text-xl leading-none">✕</button>
         </div>
         <form onSubmit={handleSubmit} className="space-y-3">
-          <input
+          <select
             className="w-full p-2 bg-neutral-800 rounded"
-            placeholder="League"
             name="league"
             value={form.league}
             onChange={handleChange}
-            required
-          />
+          >
+            {['NBA', 'NFL', 'MLB', 'PGA', 'CFL'].map((lg) => (
+              <option key={lg} value={lg}>
+                {lg}
+              </option>
+            ))}
+          </select>
+          <select
+            className="w-full p-2 bg-neutral-800 rounded"
+            name="subjectType"
+            value={form.subjectType}
+            onChange={handleChange}
+          >
+            {['Team', 'Player'].map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
           <input
             className="w-full p-2 bg-neutral-800 rounded"
             placeholder="Subject"
@@ -56,11 +81,18 @@ const AddBetModal = ({ onClose }) => {
           />
           <input
             className="w-full p-2 bg-neutral-800 rounded"
-            placeholder="Bet info"
-            name="info"
-            value={form.info}
+            placeholder="Bet description"
+            name="bet"
+            value={form.bet}
             onChange={handleChange}
             required
+          />
+          <input
+            className="w-full p-2 bg-neutral-800 rounded"
+            placeholder="Line (optional)"
+            name="line"
+            value={form.line}
+            onChange={handleChange}
           />
           <input
             className="w-full p-2 bg-neutral-800 rounded"

--- a/src/pages/AddBetPage.jsx
+++ b/src/pages/AddBetPage.jsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 
 const AddBetPage = () => {
   const [form, setForm] = useState({
-    league: "",
+    league: "NBA",
+    subjectType: "Team",
     subject: "",
-    info: "",
+    bet: "",
+    line: "",
     odds: "",
   });
   const [message, setMessage] = useState("");
@@ -25,7 +27,14 @@ const AddBetPage = () => {
       if (!res.ok) {
         throw new Error("Request failed");
       }
-      setForm({ league: "", subject: "", info: "", odds: "" });
+      setForm({
+        league: "NBA",
+        subjectType: "Team",
+        subject: "",
+        bet: "",
+        line: "",
+        odds: "",
+      });
       setMessage("Bet saved!");
     } catch {
       setMessage("Error saving bet.");
@@ -35,14 +44,30 @@ const AddBetPage = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-black text-white p-4">
       <form onSubmit={handleSubmit} className="space-y-3 w-full max-w-md bg-neutral-900 p-6 rounded">
-        <input
+        <select
           className="w-full p-2 bg-neutral-800 rounded"
-          placeholder="League"
           name="league"
           value={form.league}
           onChange={handleChange}
-          required
-        />
+        >
+          {['NBA', 'NFL', 'MLB', 'PGA', 'CFL'].map((lg) => (
+            <option key={lg} value={lg}>
+              {lg}
+            </option>
+          ))}
+        </select>
+        <select
+          className="w-full p-2 bg-neutral-800 rounded"
+          name="subjectType"
+          value={form.subjectType}
+          onChange={handleChange}
+        >
+          {['Team', 'Player'].map((st) => (
+            <option key={st} value={st}>
+              {st}
+            </option>
+          ))}
+        </select>
         <input
           className="w-full p-2 bg-neutral-800 rounded"
           placeholder="Subject"
@@ -53,11 +78,18 @@ const AddBetPage = () => {
         />
         <input
           className="w-full p-2 bg-neutral-800 rounded"
-          placeholder="Bet info"
-          name="info"
-          value={form.info}
+          placeholder="Bet description"
+          name="bet"
+          value={form.bet}
           onChange={handleChange}
           required
+        />
+        <input
+          className="w-full p-2 bg-neutral-800 rounded"
+          placeholder="Line (optional)"
+          name="line"
+          value={form.line}
+          onChange={handleChange}
         />
         <input
           className="w-full p-2 bg-neutral-800 rounded"


### PR DESCRIPTION
## Summary
- add dropdown for league choices
- track subject type (Team or Player)
- support optional line and bet description fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688974b49c7083269239b486c538d9b4