### PR TITLE
Refine props display

### DIFF
--- a/src/components/FuturesDisplay.jsx
+++ b/src/components/FuturesDisplay.jsx
@@ -12,16 +12,17 @@ const SubsectionTitle = ({ title }) => (
   <h3 className="text-lg font-semibold text-white/80 mt-4 mb-2">{title}</h3>
 );
 
-const BetRow = ({ label, rightText, starred }) => (
+const BetRow = ({ label, lineText, oddsText, rightText }) => (
   <div className="flex justify-between items-center px-3 py-[6px] rounded hover:bg-white/5 transition">
-    <span
-      className={`text-sm ${
-        starred ? "font-bold italic text-yellow-300" : "text-white"
-      }`}
-    >
-      {starred && "⭐ "} {label}
-    </span>
-    <span className="text-sm text-gray-400">{rightText}</span>
+    <span className="text-sm text-white">{label}</span>
+    {lineText && oddsText ? (
+      <span className="text-sm">
+        <span className="text-gray-200 mr-2">{lineText}</span>
+        <span className="text-gray-400">{oddsText}</span>
+      </span>
+    ) : (
+      <span className="text-sm text-gray-400">{rightText}</span>
+    )}
   </div>
 );
 
@@ -35,16 +36,17 @@ const FuturesDisplay = ({ data }) => {
           {Array.isArray(sectionValue) ? (
             <div className="space-y-1">
               {sectionValue.map((item, idx) => {
-                const text =
-                  item.line && item.odds
-                    ? `${item.ou || "o"}${item.line} ${item.odds}`
-                    : item.odds || item.bet;
+                const hasProps = item.line && item.odds;
+                const lineText = hasProps ? `${item.ou || "o"}${item.line}` : null;
+                const oddsText = hasProps ? item.odds : null;
+                const rightText = hasProps ? null : item.odds || item.bet;
                 return (
                   <BetRow
                     key={idx}
                     label={item.player || item.team}
-                    rightText={text}
-                    starred={item.starred}
+                    lineText={lineText}
+                    oddsText={oddsText}
+                    rightText={rightText}
                   />
                 );
               })}
@@ -55,16 +57,17 @@ const FuturesDisplay = ({ data }) => {
                 <SubsectionTitle title={subKey} />
                 <div className="space-y-1">
                   {subList.map((item, idx) => {
-                    const text =
-                      item.line && item.odds
-                        ? `${item.ou || "o"}${item.line} ${item.odds}`
-                        : item.odds || item.bet;
+                    const hasProps = item.line && item.odds;
+                    const lineText = hasProps ? `${item.ou || "o"}${item.line}` : null;
+                    const oddsText = hasProps ? item.odds : null;
+                    const rightText = hasProps ? null : item.odds || item.bet;
                     return (
                       <BetRow
                         key={idx}
                         label={item.player || item.team}
-                        rightText={text}
-                        starred={item.starred}
+                        lineText={lineText}
+                        oddsText={oddsText}
+                        rightText={rightText}
                       />
                     );
                   })}

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -11,16 +11,17 @@ const getCategoriesForType = (type) => {
   return categories;
 };
 
-const BetRow = ({ label, rightText, starred }) => (
+const BetRow = ({ label, lineText, oddsText, rightText }) => (
   <div className="flex justify-between items-center px-4 py-1 rounded hover:bg-white/5">
-    <span
-      className={`text-sm ${
-        starred ? "font-bold italic text-yellow-300" : "text-white"
-      }`}
-    >
-      {starred && "⭐"} {label}
-    </span>
-    <span className="text-sm text-gray-400">{rightText}</span>
+    <span className="text-sm text-white">{label}</span>
+    {lineText && oddsText ? (
+      <span className="text-sm">
+        <span className="text-gray-200 mr-2">{lineText}</span>
+        <span className="text-gray-400">{oddsText}</span>
+      </span>
+    ) : (
+      <span className="text-sm text-gray-400">{rightText}</span>
+    )}
   </div>
 );
 
@@ -79,16 +80,16 @@ const FuturesModal = () => {
         {/* Bets */}
         <div className="divide-y divide-white/5 rounded overflow-hidden">
           {filtered.map((bet, i) => {
-            const text =
-              bet.type === "Props" && bet.line && bet.odds
-                ? `${bet.ou}${bet.line} ${bet.odds}`
-                : bet.rightText;
+            const hasProps = bet.type === "Props" && bet.line && bet.odds;
+            const lineText = hasProps ? `${bet.ou || "o"}${bet.line}` : null;
+            const oddsText = hasProps ? bet.odds : null;
             return (
               <BetRow
                 key={`${bet.label}-${bet.rightText}-${i}`}
                 label={bet.label}
-                rightText={text}
-                starred={bet.starred}
+                lineText={lineText}
+                oddsText={oddsText}
+                rightText={bet.rightText}
               />
             );
           })}


### PR DESCRIPTION
## Summary
- clean up BetRow styling and remove star emoji
- visually separate line from odds in bet rows

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68897fbbcdbc8326b5699d6d4116a17f