### PR TITLE
Add league toggle and dynamic modal header

### DIFF
--- a/src/components/AddBetModal.jsx
+++ b/src/components/AddBetModal.jsx
@@ -52,7 +52,6 @@ const AddBetModal = ({ onClose }) => {
     e.preventDefault();
     setMessage("");
     try {
-      const submitDate = new Date().toISOString().split("T")[0];
       // Simulate API call
       await new Promise((resolve) => setTimeout(resolve, 500));
       setForm({

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -1,12 +1,11 @@
 // src/components/FuturesModal.jsx
 
 import React, { useState } from "react";
-import { futures } from "../data/futuresData";
+import { futuresByLeague } from "../data/futuresData";
 
 const typeOptions = ["All", "Futures", "Awards", "Props", "Leaders"];
-const getCategoriesForType = (type) => {
-  const filtered =
-    type === "All" ? futures : futures.filter((b) => b.type === type);
+const getCategoriesForType = (type, data) => {
+  const filtered = type === "All" ? data : data.filter((b) => b.type === type);
   const categories = [...new Set(filtered.map((b) => b.category))];
   return categories;
 };
@@ -36,12 +35,14 @@ const BetRow = ({ label, lineText, oddsText, rightText }) => (
   </div>
 );
 
-const FuturesModal = () => {
+const FuturesModal = ({ sport }) => {
+  const data = futuresByLeague[sport] || [];
+
   const [selectedType, setSelectedType] = useState("All");
   const [selectedCategory, setSelectedCategory] = useState("All");
 
-  const categories = getCategoriesForType(selectedType);
-  const filtered = futures.filter((b) => {
+  const categories = getCategoriesForType(selectedType, data);
+  const filtered = data.filter((b) => {
     const matchType = selectedType === "All" || b.type === selectedType;
     const matchCat =
       selectedCategory === "All" || b.category === selectedCategory;
@@ -52,7 +53,7 @@ const FuturesModal = () => {
     <div className="w-full max-w-2xl mx-auto text-white bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl p-6">
       {/* Header */}
       <div className="mb-6">
-        <h2 className="text-xl font-bold text-white mb-4">Futures & Props</h2>
+        <h2 className="text-xl font-bold text-white mb-4">{sport}</h2>
 
         {/* Tabs */}
         <div className="flex flex-wrap gap-2 mb-4">

--- a/src/data/futuresData.js
+++ b/src/data/futuresData.js
@@ -1,6 +1,7 @@
 // src/data/futuresData.js
 
-export const futures = [
+// Base NFL data used for demonstration
+const nflData = [
   // FUTURES
   {
     type: "Futures",
@@ -149,3 +150,38 @@ export const futures = [
     starred: true,
   },
 ];
+
+// Minimal sample data for other leagues
+const nbaData = [
+  { type: "Futures", category: "Championship", label: "Lakers", rightText: "+850" },
+  { type: "Awards", category: "MVP", label: "Luka Doncic", rightText: "+450" },
+  {
+    type: "Props",
+    category: "Points",
+    label: "Shai Gilgeous-Alexander",
+    rightText: "o30.5",
+    line: 30.5,
+    odds: "-110",
+    ou: "o",
+  },
+];
+
+const mlbData = [
+  { type: "Futures", category: "World Series", label: "Braves", rightText: "+350" },
+  { type: "Awards", category: "MVP", label: "Shohei Ohtani", rightText: "+150" },
+  {
+    type: "Props",
+    category: "Home Runs",
+    label: "Aaron Judge",
+    rightText: "o45.5",
+    line: 45.5,
+    odds: "-110",
+    ou: "o",
+  },
+];
+
+export const futuresByLeague = {
+  NFL: nflData,
+  NBA: nbaData,
+  MLB: mlbData,
+};

--- a/src/pages/FuturesPage.jsx
+++ b/src/pages/FuturesPage.jsx
@@ -6,8 +6,21 @@ import AddBetModal from "../components/AddBetModal";
 
 const FuturesPage = () => {
   const [showAdd, setShowAdd] = useState(false);
+  const [sport, setSport] = useState("NFL");
+
   return (
     <div className="relative">
+      <div className="absolute top-0 left-0 m-4 flex gap-2">
+        {['NFL', 'NBA', 'MLB'].map((lg) => (
+          <button
+            key={lg}
+            onClick={() => setSport(lg)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${sport === lg ? 'bg-blue-600 text-white' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white'}`}
+          >
+            {lg}
+          </button>
+        ))}
+      </div>
       <button
         onClick={() => setShowAdd(true)}
         className="absolute top-0 right-0 m-4 text-3xl text-white w-8 h-8 flex items-center justify-center rounded-full bg-neutral-800 hover:bg-neutral-700"
@@ -15,7 +28,7 @@ const FuturesPage = () => {
       >
         +
       </button>
-      <FuturesModal />
+      <FuturesModal sport={sport} />
       {showAdd && <AddBetModal onClose={() => setShowAdd(false)} />}
     </div>
   );


### PR DESCRIPTION
## Summary
- support multiple leagues by organizing data by sport
- show league switcher on Futures page
- filter modal data by selected league and display league name as the modal header
- fix eslint error in AddBetModal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688988b8d74c8326a78e62b934f0edcf