### PR TITLE
Update tag placement and controls layout

### DIFF
--- a/src/components/FuturesDisplay.jsx
+++ b/src/components/FuturesDisplay.jsx
@@ -16,16 +16,16 @@ const SubsectionTitle = ({ title }) => (
 
 const BetRow = ({ label, lineText, oddsText, rightText, tag }) => (
   <div className="flex items-center justify-between px-3 py-2 rounded bg-neutral-800/30 hover:bg-neutral-800/50 transition-colors">
-    <div className="flex-1 flex items-center gap-2">
+    <div className="flex-1">
       <span className="text-white text-sm font-medium">{label}</span>
+    </div>
+
+    <div className="flex items-center gap-3">
       {tag && (
         <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
           {tag}
         </span>
       )}
-    </div>
-
-    <div className="flex items-center gap-3">
       {lineText && oddsText ? (
         <>
           <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -22,16 +22,16 @@ const getGroupsForFutures = (data) => {
 
 const BetRow = ({ label, lineText, oddsText, rightText, tag }) => (
   <div className="flex items-center justify-between px-3 py-2 rounded bg-neutral-800/30 hover:bg-neutral-800/50 transition-colors">
-    <div className="flex-1 flex items-center gap-2">
+    <div className="flex-1">
       <span className="text-white text-sm font-medium">{label}</span>
+    </div>
+
+    <div className="flex items-center gap-3">
       {tag && (
         <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
           {tag}
         </span>
       )}
-    </div>
-
-    <div className="flex items-center gap-3">
       {lineText && oddsText ? (
         <>
           <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">

--- a/src/pages/FuturesPage.jsx
+++ b/src/pages/FuturesPage.jsx
@@ -9,25 +9,27 @@ const FuturesPage = () => {
   const [sport, setSport] = useState("NFL");
 
   return (
-    <div className="relative">
-      <div className="absolute top-0 left-0 m-4 flex gap-2">
-        {['NFL', 'NBA', 'MLB'].map((lg) => (
-          <button
-            key={lg}
-            onClick={() => setSport(lg)}
-            className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${sport === lg ? 'bg-blue-600 text-white' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white'}`}
-          >
-            {lg}
-          </button>
-        ))}
+    <div className="space-y-4 relative">
+      <div className="flex items-start justify-between">
+        <div className="flex gap-2">
+          {['NFL', 'NBA', 'MLB'].map((lg) => (
+            <button
+              key={lg}
+              onClick={() => setSport(lg)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${sport === lg ? 'bg-blue-600 text-white' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white'}`}
+            >
+              {lg}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => setShowAdd(true)}
+          className="text-3xl text-white w-8 h-8 flex items-center justify-center rounded-full bg-neutral-800 hover:bg-neutral-700"
+          aria-label="Add Bet"
+        >
+          +
+        </button>
       </div>
-      <button
-        onClick={() => setShowAdd(true)}
-        className="absolute top-0 right-0 m-4 text-3xl text-white w-8 h-8 flex items-center justify-center rounded-full bg-neutral-800 hover:bg-neutral-700"
-        aria-label="Add Bet"
-      >
-        +
-      </button>
       <FuturesModal sport={sport} />
       {showAdd && <AddBetModal onClose={() => setShowAdd(false)} />}
     </div>


### PR DESCRIPTION
## Summary
- shift league toggle and add button above the modal card
- align all category tags with the prop-style tags on the right

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68898eae943883268c74659525cc559d