### PR TITLE
Align tag layout and neutralize buttons

### DIFF
--- a/src/components/AddBetModal.jsx
+++ b/src/components/AddBetModal.jsx
@@ -227,7 +227,7 @@ const AddBetModal = ({ onClose }) => {
           <button
             type="submit"
             onClick={handleSubmit}
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg font-semibold transition-colors focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-neutral-900"
+            className="w-full bg-neutral-700 hover:bg-neutral-600 text-white py-3 rounded-lg font-semibold transition-colors focus:ring-2 focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-900"
           >
             Add Bet
           </button>

--- a/src/components/FuturesDisplay.jsx
+++ b/src/components/FuturesDisplay.jsx
@@ -16,10 +16,10 @@ const SubsectionTitle = ({ title }) => (
 
 const BetRow = ({ label, lineText, oddsText, rightText, tag }) => (
   <div className="flex items-center justify-between px-3 py-2 rounded bg-neutral-800/30 hover:bg-neutral-800/50 transition-colors">
-    <div className="flex-1 flex items-center gap-2">
+    <div className="flex-1 flex items-center">
       <span className="text-white text-sm font-medium">{label}</span>
       {tag && (
-        <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
+        <span className="ml-auto bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
           {tag}
         </span>
       )}

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -22,10 +22,10 @@ const getGroupsForFutures = (data) => {
 
 const BetRow = ({ label, lineText, oddsText, rightText, tag }) => (
   <div className="flex items-center justify-between px-3 py-2 rounded bg-neutral-800/30 hover:bg-neutral-800/50 transition-colors">
-    <div className="flex-1 flex items-center gap-2">
+    <div className="flex-1 flex items-center">
       <span className="text-white text-sm font-medium">{label}</span>
       {tag && (
-        <span className="bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
+        <span className="ml-auto bg-neutral-700 px-2 py-0.5 rounded text-xs font-medium text-neutral-200">
           {tag}
         </span>
       )}
@@ -88,7 +88,7 @@ const FuturesModal = ({ sport }) => {
               }}
               className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
                 selectedType === type
-                  ? "bg-blue-600 text-white shadow-lg"
+                  ? "bg-neutral-200 text-neutral-900 shadow-lg"
                   : "bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white"
               }`}
             >

--- a/src/pages/FuturesPage.jsx
+++ b/src/pages/FuturesPage.jsx
@@ -15,7 +15,7 @@ const FuturesPage = () => {
           <button
             key={lg}
             onClick={() => setSport(lg)}
-            className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${sport === lg ? 'bg-blue-600 text-white' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white'}`}
+            className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${sport === lg ? 'bg-neutral-200 text-neutral-900' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700 hover:text-white'}`}
           >
             {lg}
           </button>


### PR DESCRIPTION
## Summary
- align bet tag placement by pushing tag to right within BetRow
- switch league and filter buttons to neutral colors
- neutralize Add Bet submit button color

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68899139577c8326a7b0eaf7e3ba3d9d