### PR TITLE
refactor(bot): switch to interaction handler

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,28 +1,27 @@
-require("dotenv").config();
-const { Client, GatewayIntentBits } = require("discord.js");
+/* eslint-env node */
+import { Client, GatewayIntentBits, Events } from "discord.js";
+import dotenv from "dotenv";
+import process from "node:process";
+
+dotenv.config();
 
 const client = new Client({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.MessageContent,
-  ],
+  intents: [GatewayIntentBits.Guilds],
 });
 
-client.once("ready", () => {
+client.once(Events.ClientReady, () => {
   console.log(`🤖 Bot is online as ${client.user.tag}`);
 });
 
-client.on("messageCreate", (message) => {
-  if (message.content === "!ping") {
-    message.reply("🏓 Pong!");
-  }
-});
+client.on(Events.InteractionCreate, async (interaction) => {
+  if (!interaction.isChatInputCommand()) return;
 
-client.on("messageCreate", (message) => {
-  if (message.content === "/bzero") {
-    message.reply("Futures bot reporting for duty 📊");
+  if (interaction.commandName === "ping") {
+    await interaction.reply("🏓 Pong!");
+  } else if (interaction.commandName === "bzero") {
+    await interaction.reply("Futures bot reporting for duty 📊");
   }
 });
 
 client.login(process.env.DISCORD_TOKEN);
+


### PR DESCRIPTION
## Summary
- refactor bot to use slash command interactions for `ping` and `bzero`
- drop legacy message-based handlers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: remaining lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_6892c0f992648326acd9dc85d3e2e6c0