### PR TITLE
refactor: use ES modules in bot index

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,5 +1,9 @@
-require("dotenv").config();
-const { Client, GatewayIntentBits } = require("discord.js");
+/* eslint-env node */
+import dotenv from "dotenv";
+import { Client, GatewayIntentBits } from "discord.js";
+import process from "node:process";
+
+dotenv.config();
 
 const client = new Client({
   intents: [
@@ -16,11 +20,7 @@ client.once("ready", () => {
 client.on("messageCreate", (message) => {
   if (message.content === "!ping") {
     message.reply("🏓 Pong!");
-  }
-});
-
-client.on("messageCreate", (message) => {
-  if (message.content === "/bzero") {
+  } else if (message.content === "/bzero") {
     message.reply("Futures bot reporting for duty 📊");
   }
 });


### PR DESCRIPTION
## Summary
- refactor bot to use ES module imports
- merge duplicate messageCreate listeners into one handler

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: process is not defined in bot server/registerCommands)
- `cd bot && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6892c0ebda948326b80c909c917cb14f