### PR TITLE
refactor: replace body-parser with express json

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1,9 +1,8 @@
+/* global process */
 // server.js in futures-bot
 
 import express from "express";
-import bodyParser from "body-parser";
 import fs from "fs";
-import path from "path";
 import {
   Client,
   GatewayIntentBits,
@@ -20,7 +19,7 @@ const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(cors());
-app.use(bodyParser.json({ limit: "10mb" }));
+app.use(express.json({ limit: "10mb" }));
 
 // ✅ FIXED: Add full intents so bot can read messages
 const client = new Client({
@@ -62,10 +61,6 @@ client.on(Events.InteractionCreate, async (interaction) => {
     }
   }
 });
-
-function capitalize(str) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
 
 async function takeScreenshot(url) {
   const browser = await puppeteer.launch({


### PR DESCRIPTION
## Summary
- use Express's built-in JSON middleware in the bot server and remove body-parser
- drop unused helpers and declare Node's `process` global

## Testing
- `npm test` (fails: Missing script "test")
- `npm test` (in bot) (fails: Error: no test specified)
- `npx eslint bot/server.js`


------
https://chatgpt.com/codex/tasks/task_e_6892c0f203608326b4139aeab04238be