### PR TITLE
feat: enable screenshot for futures command

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,7 +1,14 @@
 // bot/index.js
 import dotenv from "dotenv";
 import process from "node:process";
-import { Client, GatewayIntentBits, Events } from "discord.js";
+import {
+  Client,
+  GatewayIntentBits,
+  Events,
+  AttachmentBuilder,
+} from "discord.js";
+import fs from "fs";
+import puppeteer from "puppeteer";
 
 dotenv.config();
 
@@ -23,12 +30,70 @@ client.on(Events.InteractionCreate, async (interaction) => {
     case "bzero":
       await interaction.reply("Futures bot reporting for duty 📊");
       break;
-    case "futures":
-      await interaction.reply("📈 Futures page screenshot coming soon!");
+    case "futures": {
+      const sport = interaction.options.getString("sport");
+      const type = interaction.options.getString("type");
+      const category = interaction.options.getString("category");
+
+      const url = `http://localhost:5173/futures?sport=${sport}&type=${type}&category=${encodeURIComponent(
+        category || ""
+      )}&group=All`;
+
+      try {
+        await interaction.deferReply();
+        const filePath = await takeScreenshot(url, sport, type, category);
+        const file = new AttachmentBuilder(filePath);
+        await interaction.editReply({ files: [file] });
+        fs.unlinkSync(filePath);
+      } catch (err) {
+        console.error("❌ Slash command failed:", err);
+        await interaction.editReply("Something went wrong!");
+      }
       break;
+    }
     default:
       await interaction.reply("❓ Unknown command");
   }
 });
 
 client.login(process.env.DISCORD_TOKEN);
+
+async function takeScreenshot(url, sport, type, category) {
+  const browser = await puppeteer.launch({
+    headless: "new",
+    defaultViewport: { width: 1000, height: 1400 },
+  });
+  const page = await browser.newPage();
+
+  await page.goto("http://localhost:5173", { waitUntil: "domcontentloaded" });
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  await page.goto(url, { waitUntil: "networkidle0" });
+
+  try {
+    await page.waitForFunction(
+      (sport, type, category) => {
+        const text = document.body.innerText.toLowerCase();
+        return (
+          text.includes(sport.toLowerCase()) &&
+          text.includes(type.toLowerCase()) &&
+          (category ? text.includes(category.toLowerCase()) : true)
+        );
+      },
+      { timeout: 10000 },
+      sport,
+      type,
+      category
+    );
+  } catch {
+    console.warn("⚠️ Betting content may not have fully loaded.");
+  }
+
+  const filePath = `screenshot_${Date.now()}.png`;
+  await page.screenshot({ path: filePath });
+  await browser.close();
+  return filePath;
+}

--- a/bot/server.js
+++ b/bot/server.js
@@ -105,7 +105,7 @@ async function takeScreenshot(url, sport, type, category) {
       type,
       category
     );
-  } catch (err) {
+  } catch {
     console.warn("⚠️ Betting content may not have fully loaded.");
   }
 


### PR DESCRIPTION
## Summary
- add puppeteer screenshot logic to Discord bot futures command
- clean up unused variable in screenshot server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892dc5edbf883269e80a7c64e2405a7