### PR TITLE
Load Discord credentials from bot env

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -9,8 +9,13 @@ import {
 } from "discord.js";
 import fs from "fs";
 import puppeteer from "puppeteer";
+import path from "path";
+import { fileURLToPath } from "url";
 
-dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds],

--- a/bot/scripts/registerCommands.js
+++ b/bot/scripts/registerCommands.js
@@ -3,9 +3,13 @@
 
 import { REST, Routes } from "discord.js";
 import dotenv from "dotenv";
+import path from "path";
+import { fileURLToPath } from "url";
 
 // Load environment variables
-dotenv.config({ override: true });
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenv.config({ path: path.resolve(__dirname, "../.env"), override: true });
 
 const { DISCORD_TOKEN, CLIENT_ID } = process.env;
 if (!DISCORD_TOKEN || !CLIENT_ID) {

--- a/bot/server.js
+++ b/bot/server.js
@@ -12,8 +12,13 @@ import {
 import dotenv from "dotenv";
 import cors from "cors";
 import puppeteer from "puppeteer";
+import path from "path";
+import { fileURLToPath } from "url";
 
-dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 const app = express();
 const port = process.env.PORT || 3002; // ⚠️ Changed from 3001 to avoid conflict with main API


### PR DESCRIPTION
## Summary
- ensure bot server and scripts load Discord token and client IDs from `bot/.env`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892f42d21f483268a947ad5fcd74998