### PR TITLE
feat: load saved bets into display

### DIFF
--- a/src/components/AddBetModal.jsx
+++ b/src/components/AddBetModal.jsx
@@ -93,26 +93,27 @@ const AddBetModal = ({ onClose }) => {
     const playerKey = form.player.trim().toLowerCase();
     const teamName = form.team || playerTeamMap[playerKey] || "";
 
-    try {
-      const res = await fetch("/api/bets", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...form, team: teamName }),
-      });
+      try {
+        const res = await fetch("/api/bets", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...form, team: teamName }),
+        });
 
-      if (!res.ok) throw new Error("Request failed");
+        if (!res.ok) throw new Error("Request failed");
 
-      if (playerKey && teamName) {
-        playerTeamMap[playerKey] = teamName;
+        if (playerKey && teamName) {
+          playerTeamMap[playerKey] = teamName;
+        }
+
+        setForm(initialForm);
+        setMessage("Bet saved!");
+        window.dispatchEvent(new Event("betsUpdated"));
+      } catch {
+        setIsError(true);
+        setMessage("Error saving bet.");
       }
-
-      setForm(initialForm);
-      setMessage("Bet saved!");
-    } catch {
-      setIsError(true);
-      setMessage("Error saving bet.");
-    }
-  };
+    };
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -29,7 +29,8 @@ const BetRow = ({ label, lineText, oddsText, rightText, tag, league }) => {
   // Load player→team map
   const map = JSON.parse(localStorage.getItem("playerTeamMap") || "{}");
   const team = map[label];
-  const logoSrc = team && league === "NBA" ? nbaLogoMap[team] : null;
+  const logoMaps = { NBA: nbaLogoMap, NFL: nflLogoMap, MLB: mlbLogoMap };
+  const logoSrc = team && logoMaps[league] ? logoMaps[league][team] : null;
 
   return (
     <div className="relative overflow-hidden rounded bg-neutral-800/30 hover:bg-neutral-800/50 transition-colors px-3 py-2">
@@ -65,7 +66,9 @@ const BetRow = ({ label, lineText, oddsText, rightText, tag, league }) => {
 };
 
 const FuturesModal = ({ sport }) => {
-  const data = futuresByLeague[sport] || [];
+  const [allBets, setAllBets] = useState({});
+  const baseData = futuresByLeague[sport] || [];
+  const data = [...(allBets[sport] || []), ...baseData];
   const [params] = useSearchParams();
   const navigate = useNavigate();
 
@@ -84,7 +87,41 @@ const FuturesModal = ({ sport }) => {
     nextParams.set("category", selectedCategory);
     nextParams.set("group", selectedGroup);
     navigate(`?${nextParams.toString()}`, { replace: true });
-  }, [sport, selectedType, selectedCategory, selectedGroup]);
+  }, [sport, selectedType, selectedCategory, selectedGroup, navigate]);
+
+  useEffect(() => {
+    const loadBets = async () => {
+      try {
+        const res = await fetch("/api/bets");
+        const json = await res.json();
+        const formatted = {};
+        Object.entries(json).forEach(([league, types]) => {
+          const items = [];
+          Object.values(types).forEach((arr) => {
+            arr.forEach((b) => {
+              items.push({
+                type: b.type,
+                category: b.category || "",
+                label: b.player || b.team,
+                line: b.line,
+                odds: b.odds,
+                ou: b.ou ? b.ou[0].toLowerCase() : "",
+                group: b.group || "",
+                rightText: b.odds,
+              });
+            });
+          });
+          formatted[league] = items;
+        });
+        setAllBets(formatted);
+      } catch (err) {
+        console.error("Failed to load bets", err);
+      }
+    };
+    loadBets();
+    window.addEventListener("betsUpdated", loadBets);
+    return () => window.removeEventListener("betsUpdated", loadBets);
+  }, []);
 
   const groups = getGroupsForFutures(data);
   const categories = getCategoriesForType(selectedType, data, selectedGroup);


### PR DESCRIPTION
## Summary
- fetch bets from local API and merge with static futures
- refresh bets list when new bet added

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68931eb6583483268720a66273dec327