### PR TITLE
feat: add vercel serverless endpoints

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,28 @@
+# Deploying to Vercel
+
+## Required environment variables
+
+- `DISCORD_PUBLIC_KEY`
+- `PUBLIC_BASE_URL`
+
+## Interactions endpoint
+
+Deploy the interactions handler at:
+
+```
+https://<your-domain>/api/interactions
+```
+
+## Test routes
+
+```
+GET /api/snap?url=data:text/html,<h1>ok</h1>
+GET /api/snap?url=https%3A%2F%2Fexample.com
+```
+
+## Runtime logs
+
+On Vercel, open the Runtime Logs tab and filter by:
+
+- `path:/api/interactions`
+- `path:/api/snap`

--- a/api/interactions.mjs
+++ b/api/interactions.mjs
@@ -1,26 +1,22 @@
-// api/interactions.mjs — Discord Interactions handler (reads sport/type/category)
+// api/interactions.mjs — Discord Interactions (ESM)
 import nacl from "tweetnacl";
 
 function getStrOpt(interaction, name, def = "") {
   const opts = interaction?.data?.options || [];
-  const found = opts.find(
-    (o) => (o?.name || "").toLowerCase() === name.toLowerCase()
-  );
-  return found && typeof found.value !== "undefined"
-    ? String(found.value)
-    : def;
+  const found = opts.find(o => (o?.name || "").toLowerCase() === name.toLowerCase());
+  return (found && typeof found.value !== "undefined") ? String(found.value) : def;
 }
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).send("Method Not Allowed");
 
-  // raw body for signature verify
+  // Buffer raw body (required for signature verification)
   const chunks = [];
   for await (const c of req) chunks.push(c);
   const raw = Buffer.concat(chunks);
 
   const sig = req.headers["x-signature-ed25519"];
-  const ts = req.headers["x-signature-timestamp"];
+  const ts  = req.headers["x-signature-timestamp"];
   const key = process.env.DISCORD_PUBLIC_KEY;
   if (!sig || !ts || !key) return res.status(401).send("Missing headers/env");
 
@@ -39,57 +35,35 @@ export default async function handler(req, res) {
 
     switch (name) {
       case "ping":
-        return res.status(200).json({
-          type: 4,
-          data: { content: "🏓 Pong from Vercel" },
-        });
+        return res.status(200).json({ type: 4, data: { content: "🏓 Pong from Vercel" } });
 
       case "futures": {
-        // Your slash-command options (from your register script)
-        const sport = getStrOpt(i, "sport", "NFL"); // NFL/NBA/MLB
-        const type = getStrOpt(i, "type", "Futures"); // All/Futures/Awards/Props/Leaders
-        const category = getStrOpt(i, "category", ""); // optional
-
-        const base = process.env.PUBLIC_BASE_URL; // e.g., https://futures-tracker.vercel.app
+        const sport    = getStrOpt(i, "sport", "NFL");
+        const type     = getStrOpt(i, "type", "Futures");
+        const category = getStrOpt(i, "category", "");
+        const base = process.env.PUBLIC_BASE_URL;
         if (!base) {
           return res.status(200).json({
             type: 4,
-            data: {
-              content: "Config missing: set PUBLIC_BASE_URL in Vercel env",
-            },
+            data: { content: "Config missing: set PUBLIC_BASE_URL in Vercel env" }
           });
         }
-
-        // Build the page URL your site understands. Use your param names.
-        // If your frontend expects different keys, change these (e.g., league/tab).
-        const params = new URLSearchParams();
-        if (sport) params.set("sport", sport);
-        if (type) params.set("type", type);
-        if (category) params.set("category", category);
-
         const siteBase = base.replace(/\/$/, "");
+        const params = new URLSearchParams();
+        if (sport)    params.set("sport", sport);
+        if (type)     params.set("type", type);
+        if (category) params.set("category", category);
         const target = `${siteBase}/futures?${params.toString()}`;
-
-        // Ask /api/snap to capture that specific page state
-        const snap = `${siteBase}/api/snap?url=${encodeURIComponent(
-          target
-        )}&w=1080&h=1350&wait=1000&t=${Date.now()}`;
+        const snap = `${siteBase}/api/snap?url=${encodeURIComponent(target)}&w=1080&h=1350&wait=1200&t=${Date.now()}`;
 
         return res.status(200).json({
           type: 4,
-          data: {
-            content: `📈 Futures Snapshot (${sport} • ${type}${
-              category ? " • " + category : ""
-            })\n${snap}`,
-          },
+          data: { content: `📈 Futures Snapshot (${sport} • ${type}${category ? " • " + category : ""})\n${snap}` }
         });
       }
 
       default:
-        return res.status(200).json({
-          type: 4,
-          data: { content: `🤔 Unknown command: \`${name}\`` },
-        });
+        return res.status(200).json({ type: 4, data: { content: `🤔 Unknown command: \`${name}\`` } });
     }
   }
 


### PR DESCRIPTION
## Summary
- add Discord interactions handler for slash commands and ping
- add serverless screenshot route using puppeteer-core and @sparticuz/chromium
- document Vercel deployment requirements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b51359e2c83268ced85360c2bbd14