### PR TITLE
Normalize futures params and categories

### DIFF
--- a/src/pages/FuturesPage.jsx
+++ b/src/pages/FuturesPage.jsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import FuturesModal from "../components/FuturesModal";
 import AddBetModal from "../components/AddBetModal";
+import { coerceSport, coerceCategory, coerceMarket } from "../utils/naming";
 
 const FuturesPage = () => {
   const [params] = useSearchParams();
@@ -12,14 +13,16 @@ const FuturesPage = () => {
   const [deleteMode, setDeleteMode] = useState(false);
 
   // Read from URL
-  const sport = params.get("sport") || "NFL";
-  const category = params.get("category") || "All";
+  const sport = coerceSport(params.get("sport"));
+  const category = coerceCategory(params);
+  const market = coerceMarket(params);
 
   const handleSportChange = (newSport) => {
     const newParams = new URLSearchParams(params);
     newParams.set("sport", newSport);
     // when switching sports, default to All
     newParams.set("category", "All");
+    newParams.delete("market");
     navigate(`?${newParams.toString()}`);
   };
 
@@ -110,6 +113,7 @@ const FuturesPage = () => {
         <FuturesModal
           sport={sport}
           category={category}
+          market={market}
           deleteMode={deleteMode}
         />
       </div>


### PR DESCRIPTION
## Summary
- Read `sport`, `category`, and `market` from URL and pass through to the futures modal
- Simplify futures modal tabs to canonical categories with URL sync and active-category tagging
- Save new bets with normalized keys (sport, category, market, selection, odds)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dc613d2c48326b522708adde7af32