### PR TITLE
refactor: replace legacy identifiers

### DIFF
--- a/api/bets.mjs
+++ b/api/bets.mjs
@@ -13,41 +13,43 @@ export default async function handler(req, res) {
     try {
       const currentBets = await getAllBets();
       const {
-        type,
-        tabLabel,
-        player,
-        team,
-        image,
-        details,
-        odds,
-        site,
-        league,
+        sport,
+        category,
+        market,
+        selection,
+        odds_american,
+        line,
+        book,
+        notes,
       } = req.body;
 
-      if (!type || !tabLabel || !team || !odds || !site || !league) {
+      const s = sport ?? req.body.league;
+      const cat = category ?? req.body.tabLabel ?? req.body.type;
+      const odds = odds_american ?? req.body.odds;
+
+      if (!s || !cat || !selection || !odds || !book) {
         return res.status(400).json({ error: "Missing required fields" });
       }
 
       const newBet = {
-        type,
-        tabLabel,
-        player: player ?? null,
-        team,
-        image: image || "",
-        details: details || {},
-        odds,
-        site,
-        league,
-        date: new Date().toISOString(),
+        sport: s,
+        category: cat,
+        market: market ?? req.body.subtype ?? "",
+        selection,
+        odds_american: odds,
+        line: line ?? null,
+        book,
+        notes: notes ?? "",
+        createdAt: Date.now(),
       };
 
-      if (!currentBets[league]) currentBets[league] = {};
-      if (!currentBets[league][tabLabel]) currentBets[league][tabLabel] = [];
-      currentBets[league][tabLabel].unshift(newBet);
+      if (!currentBets[s]) currentBets[s] = {};
+      if (!currentBets[s][cat]) currentBets[s][cat] = [];
+      currentBets[s][cat].unshift(newBet);
 
       // Optional: Limit array size to prevent KV store from growing too large
-      if (currentBets[league][tabLabel].length > 100) {
-        currentBets[league][tabLabel] = currentBets[league][tabLabel].slice(0, 100);
+      if (currentBets[s][cat].length > 100) {
+        currentBets[s][cat] = currentBets[s][cat].slice(0, 100);
       }
 
       await saveBets(currentBets);

--- a/api/bets/delete.mjs
+++ b/api/bets/delete.mjs
@@ -15,9 +15,21 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { league, tabLabel, date, player, team, odds, site } = req.body;
+    const {
+      sport,
+      category,
+      createdAt,
+      player,
+      team,
+      odds_american,
+      book,
+    } = req.body;
 
-    if (!league || !tabLabel || !date) {
+    const s = sport ?? req.body.league;
+    const cat = category ?? req.body.tabLabel;
+    const ts = createdAt ?? req.body.date;
+
+    if (!s || !cat || !ts) {
       return res.status(400).json({ error: "Missing required fields" });
     }
 
@@ -30,24 +42,24 @@ export default async function handler(req, res) {
       return res.status(500).json({ error: "Failed to read bets database" });
     }
 
-    if (!currentBets[league] || !currentBets[league][tabLabel]) {
-      return res.status(404).json({ error: "League or tab not found" });
+    if (!currentBets[s] || !currentBets[s][cat]) {
+      return res.status(404).json({ error: "Sport or category not found" });
     }
 
     const normalize = (v) => (v === undefined || v === null ? "" : String(v));
 
-    const before = currentBets[league][tabLabel].length;
-    currentBets[league][tabLabel] = currentBets[league][tabLabel].filter(
+    const before = currentBets[s][cat].length;
+    currentBets[s][cat] = currentBets[s][cat].filter(
       (b) =>
         !(
-          String(b.date) === String(date) &&
-          normalize(b.player) === normalize(player) &&
+          String(b.createdAt ?? b.date) === String(ts) &&
+          normalize(b.selection ?? b.player) === normalize(player) &&
           normalize(b.team) === normalize(team) &&
-          normalize(b.odds) === normalize(odds) &&
-          normalize(b.site) === normalize(site)
+          normalize(b.odds_american ?? b.odds) === normalize(odds_american) &&
+          normalize(b.book ?? b.site) === normalize(book)
         )
     );
-    const after = currentBets[league][tabLabel].length;
+    const after = currentBets[s][cat].length;
     const removed = before - after;
 
     if (removed === 0) {

--- a/bot/server.js
+++ b/bot/server.js
@@ -56,14 +56,14 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
   if (interaction.commandName === "futures") {
     const sport = interaction.options.getString("sport");
-    const type = interaction.options.getString("type");
     const category = interaction.options.getString("category");
+    const market = interaction.options.getString("market");
 
     // Use environment variable for base URL or fallback to localhost for development
     const baseUrl = process.env.APP_URL || "http://localhost:5173";
-    const url = `${baseUrl}/futures?sport=${sport}&type=${type}&category=${encodeURIComponent(
-      category || ""
-    )}&group=All`;
+    const url = `${baseUrl}/futures?sport=${sport}&category=${encodeURIComponent(
+      category || "All"
+    )}${market ? `&market=${encodeURIComponent(market)}` : ""}`;
 
     try {
       await interaction.deferReply({ ephemeral: false });

--- a/src/components/BetRow.jsx
+++ b/src/components/BetRow.jsx
@@ -6,13 +6,13 @@ import getHeadshotUrl from "../utils/getHeadshotUrl";
 import logoBgPosition from "../data/logoBgPosition";
 import { deleteBet } from "../utils/betService";
 
-// Map league -> team logo
+// Map sport -> team logo
 // Enhanced getTeamLogo: supports full team names
-const getTeamLogo = (league, team) => {
+const getTeamLogo = (sport, team) => {
   let map;
-  if (league === "NBA") map = nbaLogoMap;
-  else if (league === "NFL") map = nflLogoMap;
-  else if (league === "MLB") map = mlbLogoMap;
+  if (sport === "NBA") map = nbaLogoMap;
+  else if (sport === "NFL") map = nflLogoMap;
+  else if (sport === "MLB") map = mlbLogoMap;
   else map = {};
 
   // Try direct match
@@ -94,33 +94,34 @@ function splitTeamName(team = "") {
 }
 
 const BetRow = ({ bet, deleteMode }) => {
-  const { type, player, team, image, odds, league, details = {} } = bet || {};
-  const logoUrl = getTeamLogo(league, team);
+  const { category, player, team, image, odds_american, sport, details = {} } =
+    bet || {};
+  const logoUrl = getTeamLogo(sport, team);
 
-  // For Team Bet, use team logo as headshot
-  const isTeamLogo = type === "Team Bet";
+  // For Team Futures, use team logo as headshot
+  const isTeamLogo = category === "Team Futures";
   const headshotSrc = isTeamLogo
     ? logoUrl
-    : getHeadshotUrl(player, league, image);
+    : getHeadshotUrl(player, sport, image);
 
   // Main label
   let label = "";
   let labelTop = "";
   let labelBottom = "";
-  switch (type) {
-    case "Player Award":
+  switch (category) {
+    case "Awards":
       label = player;
       [labelTop, labelBottom] = splitPlayerName(player || "");
       break;
-    case "Team Bet":
+    case "Team Futures":
       label = team;
       [labelTop, labelBottom] = splitTeamName(team || "");
       break;
-    case "Stat Leader":
+    case "Stat Leaders":
       label = player;
       [labelTop, labelBottom] = splitPlayerName(player || "");
       break;
-    case "Prop":
+    case "Props":
       label = player;
       [labelTop, labelBottom] = splitPlayerName(player || "");
       break;
@@ -131,9 +132,9 @@ const BetRow = ({ bet, deleteMode }) => {
 
   // Pill text
   let tag = "";
-  if (type === "Player Award") {
+  if (category === "Awards") {
     tag = details.award || "";
-  } else if (type === "Team Bet") {
+  } else if (category === "Team Futures") {
     const ou = details.ou === "Over" ? "o" : details.ou === "Under" ? "u" : "";
     if (details.value) {
       // Change 'Win Total' to 'Wins' for display
@@ -142,9 +143,9 @@ const BetRow = ({ bet, deleteMode }) => {
     } else {
       tag = details.bet === "Win Total" ? "Wins" : details.bet || "";
     }
-  } else if (type === "Stat Leader") {
+  } else if (category === "Stat Leaders") {
     tag = details.stat || "";
-  } else if (type === "Prop") {
+  } else if (category === "Props") {
     const ou = details.ou === "Over" ? "o" : details.ou === "Under" ? "u" : "";
     tag = `${ou}${details.line || ""} ${details.stat || ""}`.trim();
   }
@@ -153,13 +154,9 @@ const BetRow = ({ bet, deleteMode }) => {
     if (!window.confirm("Remove this bet?")) return;
     try {
       await deleteBet({
-        league: bet.league,
-        tabLabel: bet.tabLabel,
-        date: bet.date,
-        player: bet.player || null,
-        team: bet.team,
-        odds: bet.odds,
-        site: bet.site,
+        sport: bet.sport || bet.league,
+        category: bet.category || bet.tabLabel || bet.type,
+        createdAt: bet.createdAt || bet.date,
       });
       window.dispatchEvent(new Event("betsUpdated"));
     } catch (error) {
@@ -239,9 +236,9 @@ const BetRow = ({ bet, deleteMode }) => {
           </div>
           {/* Odds: always right-aligned, fixed width */}
           <div className="flex-shrink-0 w-[70px] ml-2 flex items-center justify-end">
-            {odds ? (
+            {odds_american ? (
               <span className="text-white text-sm md:text-base font-bold tracking-widest whitespace-nowrap">
-                {odds}
+                {odds_american}
               </span>
             ) : null}
           </div>

--- a/src/components/FuturesModal.jsx
+++ b/src/components/FuturesModal.jsx
@@ -16,19 +16,19 @@ const FuturesModal = ({ sport, category, market, deleteMode }) => {
     setActiveCategory(category || "All");
   }, [category]);
 
-  // Fetch bets for league
+  // Fetch bets for sport
   useEffect(() => {
     const fetchData = async () => {
       try {
         const result = await getAllBets();
-        let leagueBets = [];
+        let sportBets = [];
         if (result && result[sport]) {
           Object.values(result[sport]).forEach((arr) => {
-            leagueBets = leagueBets.concat(arr);
+            sportBets = sportBets.concat(arr);
           });
         }
         setData(
-          leagueBets.map((b) => ({
+          sportBets.map((b) => ({
             ...b,
             sport: b.sport ?? b.league,
             category: b.category ?? b.type ?? b.tabLabel ?? "All",
@@ -51,8 +51,6 @@ const FuturesModal = ({ sport, category, market, deleteMode }) => {
     const el = document.getElementById("futures-modal");
     if (el) {
       el.setAttribute("data-active-category", activeCategory);
-      // legacy alias
-      el.setAttribute("data-active-group", activeCategory);
     }
   }, [activeCategory]);
 

--- a/src/utils/betService.js
+++ b/src/utils/betService.js
@@ -39,8 +39,8 @@ export async function addBet(bet) {
     const { sport, category } = bet;
     if (!sport || !category) throw new Error("Missing required fields");
 
-    const leagueRef = ref(db, `${BETS_REF}/${sport}/${category}`);
-    const snapshot = await get(leagueRef);
+    const sportRef = ref(db, `${BETS_REF}/${sport}/${category}`);
+    const snapshot = await get(sportRef);
     const currentBets = snapshot.val() || [];
 
     const payload = {
@@ -54,19 +54,13 @@ export async function addBet(bet) {
       notes: bet.notes ?? "",
       createdAt: bet.createdAt ?? Date.now(),
     };
-    // TEMP legacy mirrors
-    payload.league = payload.sport;
-    payload.type = payload.category;
-    payload.subtype = payload.market;
-    payload.odds = payload.odds_american;
-
     currentBets.unshift(payload);
 
     if (currentBets.length > 100) {
       currentBets.length = 100;
     }
 
-    await set(leagueRef, currentBets, { headers: { origin: appOrigin } });
+    await set(sportRef, currentBets, { headers: { origin: appOrigin } });
     return payload;
   } catch (err) {
     console.error("Failed to save bet:", err);
@@ -80,8 +74,8 @@ export async function deleteBet({ sport, category, createdAt }) {
       throw new Error("Missing required fields");
     }
 
-    const leagueRef = ref(db, `${BETS_REF}/${sport}/${category}`);
-    const snapshot = await get(leagueRef);
+    const sportRef = ref(db, `${BETS_REF}/${sport}/${category}`);
+    const snapshot = await get(sportRef);
     const bets = snapshot.val() || [];
 
     const filteredBets = bets.filter(
@@ -92,7 +86,7 @@ export async function deleteBet({ sport, category, createdAt }) {
       throw new Error("Bet not found");
     }
 
-    await set(leagueRef, filteredBets, { headers: { origin: appOrigin } });
+    await set(sportRef, filteredBets, { headers: { origin: appOrigin } });
     return { removed: bets.length - filteredBets.length };
   } catch (err) {
     console.error("Failed to delete bet:", err);

--- a/src/utils/getHeadshotUrl.js
+++ b/src/utils/getHeadshotUrl.js
@@ -1,8 +1,8 @@
 import playerHeadshots from "../data/playerHeadshots.json";
 
-export function getHeadshotUrl(player, league, providedImage) {
+export function getHeadshotUrl(player, sport, providedImage) {
   if (providedImage) return providedImage;
-  if (league !== "NFL") return null;
+  if (sport !== "NFL") return null;
   return playerHeadshots[player] || null;
 }
 


### PR DESCRIPTION
## Summary
- align backend and UI with sport/category/market keys
- update slash command handler for new parameters
- remove legacy field mirrors and data-active-group

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`
- `node bot/scripts/registerCommands.js` *(fails: Missing DISCORD_TOKEN or CLIENT_ID)*

------
https://chatgpt.com/codex/tasks/task_e_689dc9ca69fc8326b0d793e3419d4103