### PR TITLE
Fix slash command screenshot base resolution

### DIFF
--- a/api/discord-followup.js
+++ b/api/discord-followup.js
@@ -1,3 +1,4 @@
+/* global process, Buffer */
 // api/discord-followup.js — posts image to the channel using Bot token, then deletes spinner
 import { FormData, fetch } from "undici";
 


### PR DESCRIPTION
## Summary
- derive base URL from environment or request host so slash command triggers `/api/snap` and deletes spinner
- document Node globals for API handlers and log interaction errors
- ignore `X-Forwarded-Host` header from Discord so screenshot fetch points to our deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eee723a088326b93b9f31e3ccdd1d